### PR TITLE
show more than 25 options, only show active options

### DIFF
--- a/src/Resources/app/administration/src/extension/sw-order-list/index.js
+++ b/src/Resources/app/administration/src/extension/sw-order-list/index.js
@@ -227,6 +227,8 @@ Component.override('sw-order-list', {
         async getDefaultOptions() {
             const criteria = new Criteria();
             criteria.addSorting({ field: 'name', order: 'ASC' });
+            criteria.addFilter(Criteria.equals('active', true));
+            criteria.setLimit(50);
 
             Promise.all([
                 this.getShippingMethods(criteria),


### PR DESCRIPTION
* show up to 50 Options (Sales Channels, Payment Methods, Shipping Methods) instead of default 25
* only show active ShippingMethods, PaymentMethods and SalesChannels